### PR TITLE
Avoid empty link when no image is available

### DIFF
--- a/widget.php
+++ b/widget.php
@@ -404,7 +404,7 @@ class GS_Featured_Content extends WP_Widget {
 				'attr'    => genesis_parse_attr( 'gsfc-entry-image-widget', array( 'align' => $align, ) ),
 			) );
         
-        $image = $instance['link_image'] == 1 ? sprintf( '<a href="%s" title="%s" class="%s">%s</a>', $link, the_title_attribute( 'echo=0' ), $align, $image ) : $image;
+        $image = $instance['link_image'] == 1 && ! empty( $image ) ? sprintf( '<a href="%s" title="%s" class="%s">%s</a>', $link, the_title_attribute( 'echo=0' ), $align, $image ) : $image;
         
         GS_Featured_Content::maybe_echo( $instance, 'gsfc_before_post_content', 'image_position', 'before-title', $image );
         GS_Featured_Content::maybe_echo( $instance, 'gsfc_post_content', 'image_position', 'after-title', $image );


### PR DESCRIPTION
When the link_image option is set, articles that do not have a featured image got an empty link even if there's no image. This change just avoids the output of such empty links.
